### PR TITLE
Attempt 2: avoid use of seticon

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,11 @@ You should see a bunch of new `.iconset` folders and `.icns` files that were aut
 - Included with macOS:
   - Python (version 2 or 3).
   - `iconutil`
+  - `sips`, `DeRez`, `Rez`, `SetFile`
+    - Only used if the `--builtin`/`-b` option is specified.
 - Bundled with `folderify`:
   - [`osxiconutils`](http://www.sveinbjorn.org/osxiconutils), a GPL-licensed project by Sveinbjorn Thordarson (based on [`IconFamily`](http://iconfamily.sourceforge.net/)).
+    - This is used unless the `--builtin`/`-b` option is specified.
 
 # Full options
 
@@ -119,6 +122,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --builtin, -b         Use built-in macOS tools in place of seticon.
   --reveal, -r          Reveal the target (or resulting .icns file) in Finder.
   --macOS VERSION       Version of the macOS folder icon, e.g. "10.13". Defaults to the version currently running (10.15).
   --osx VERSION, -x VERSION

--- a/folderify/__main__.py
+++ b/folderify/__main__.py
@@ -151,9 +151,9 @@ Defaults to the version currently running (%s)." % LOCAL_MACOS_VERSION))
   convert_path = "convert"
   iconutil_path = "iconutil"
   sips_path = "sips"
-  DeRez_path = "DeRez"
-  Rez_path = "Rez"
-  SetFile_path = "SetFile"
+  deRez_path = "DeRez"
+  rez_path = "Rez"
+  setFile_path = "SetFile"
   seticon_path = os.path.join(data_folder, "lib", "seticon")
 
   ################################################################
@@ -517,7 +517,7 @@ or
         # DeRez: export the icns resource from the icns file
         with open(temp_file, "w") as f:
           subprocess.check_call([
-            DeRez_path,
+            deRez_path,
             "-only",
             "icns",
             icns_file
@@ -525,7 +525,7 @@ or
 
         # Rez: add exported icns resource to the resource fork of target/Icon^M
         subprocess.check_call([
-          Rez_path,
+          rez_path,
           "-append",
           temp_file,
           "-o",
@@ -534,7 +534,7 @@ or
 
         # SetFile: set custom icon attribute
         subprocess.check_call([
-          SetFile_path,
+          setFile_path,
           "-a",
           "C",
           target
@@ -542,7 +542,7 @@ or
 
         # SetFile: set hidden file attribute
         subprocess.check_call([
-          SetFile_path,
+          setFile_path,
           "-a",
           "V",
           target_icon


### PR DESCRIPTION
This adds a new `--builtin`/`-b` option that uses built-in tools (`sips`, `DeRez`, `Rez`, `SetFile`) in place of the `seticon` binary in the repository.

Note that this seems to produce a slightly smaller icon resource -

```
$ ls -l with-seticon/Icon^M/..namedfork/rsrc
-rw-r--r--  1 crdaviso  staff  1546770 17 May 11:14 with-seticon/Icon?/..namedfork/rsrc
$ ls -l with-sips/Icon^M/..namedfork/rsrc
-rw-r--r--  1 crdaviso  staff  1151288 17 May 11:36 with-sips/Icon?/..namedfork/rsrc
```

However, all the icons in the set appear to be there.
