### PR TITLE
Improve test

### DIFF
--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -24,11 +24,27 @@ function check_folder {
 
 function check_folder_icon {
   FILE="${1}/"
-  if test -f "${FILE}"Icon$'\r'
+  ICON="${FILE}"Icon$'\r'
+  # Check for "custom icon" attribute on target
+  if xattr -p com.apple.FinderInfo "${FILE}" > /dev/null
   then
-    echo "✅ Folder ${FILE} has an icon as expected."
+    # Check for "invisible" attribute on icon
+    if xattr -p com.apple.FinderInfo "${ICON}" > /dev/null
+    then
+      # Check for icns data in icon
+      if xattr -p com.apple.ResourceFork "${ICON}" > /dev/null
+      then
+        echo "✅ Folder ${FILE} has an icon as expected."
+      else
+        echo "❌ Folder ${FILE} icon should have a resource fork, but doesn't."
+        exit 1
+      fi
+    else
+      echo "❌ Folder ${FILE} icon should have a FinderInfo attribute, but doesn't."
+      exit 1
+    fi
   else
-    echo "❌ Folder ${FILE} should have an icon, but doesn't."
+    echo "❌ Folder ${FILE} should have a FinderInfo attribute, but doesn't."
     exit 1
   fi
 }

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -26,25 +26,22 @@ function check_folder_icon {
   FILE="${1}/"
   ICON="${FILE}"Icon$'\r'
   # Check for "custom icon" attribute on target
-  if xattr -p com.apple.FinderInfo "${FILE}" > /dev/null
+  if ! xattr -p com.apple.FinderInfo "${FILE}" > /dev/null
   then
-    # Check for "invisible" attribute on icon
-    if xattr -p com.apple.FinderInfo "${ICON}" > /dev/null
-    then
-      # Check for icns data in icon
-      if xattr -p com.apple.ResourceFork "${ICON}" > /dev/null
-      then
-        echo "✅ Folder ${FILE} has an icon as expected."
-      else
-        echo "❌ Folder ${FILE} icon should have a resource fork, but doesn't."
-        exit 1
-      fi
-    else
-      echo "❌ Folder ${FILE} icon should have a FinderInfo attribute, but doesn't."
-      exit 1
-    fi
-  else
     echo "❌ Folder ${FILE} should have a FinderInfo attribute, but doesn't."
     exit 1
   fi
+  # Check for "invisible" attribute on icon
+  if ! xattr -p com.apple.FinderInfo "${ICON}" > /dev/null
+  then
+    echo "❌ Folder ${FILE} icon should have a FinderInfo attribute, but doesn't."
+    exit 1
+  fi
+  # Check for icns data in icon
+  if ! xattr -p com.apple.ResourceFork "${ICON}" > /dev/null
+  then
+    echo "❌ Folder ${FILE} icon should have a resource fork, but doesn't."
+    exit 1
+  fi
+  echo "✅ Folder ${FILE} has an icon as expected."
 }


### PR DESCRIPTION
Check for folder/icon attributes, beyond just checking for existence.

This could be improved later by actually parsing out the attributes:

```
$ xattr -l -p com.apple.FinderInfo .
com.apple.FinderInfo:
00000000  00 00 00 00 00 00 00 00 04 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00  |................|
00000020
```

(The 04 byte means "custom icon").

There is a GetFileInfo tool that could be used for that, but it's not clear to me that it will always be available.

```
$ GetFileInfo . | grep -E ^attributes
attributes: avbstClinmedz
```

(C is for "custom icon")

Anyway, I think just checking for the existence of these attributes is an improvement in itself.
