### PR TITLE
Update folderify package version in Cargo.lock from 3.0.12 to 3.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,7 @@ dependencies = [
 
 [[package]]
 name = "folderify"
-version = "3.0.12"
+version = "3.0.13"
 dependencies = [
  "clap",
  "clap_complete",


### PR DESCRIPTION
This updates the package version for `folderify` in Cargo.lock from `3.0.12` to `3.0.13` to match the latest release version.

context: I was trying to package this with Nix and the build was failing because the lock file is out-of-date