### PR TITLE
Allow applying one mask to multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Use a mask to assign an icon to a folder:
 folderify mask.png /path/to/folder
 ```
 
+Use the same mask for multiple folders in one run:
+
+```shell
+folderify mask.png /path/to/folder-1 /path/to/folder-2 /path/to/folder-3
+```
+
 Generate `mask.icns` and `mask.iconset` files:
 
 ```shell

--- a/src/args.rs
+++ b/src/args.rs
@@ -23,13 +23,13 @@ struct FolderifyArgs {
     #[clap(verbatim_doc_comment)]
     mask: Option<PathBuf>,
 
-    /// Target file or folder. If a target is specified, the resulting icon will
-    /// be applied to the target file/folder. Else (unless --output-icns or
+    /// Target files or folders. If any targets are specified, the resulting icon
+    /// will be applied to each target. Else (unless --output-icns or
     /// --output-iconset is specified), a .iconset folder and .icns file will be
     /// created in the same folder as the mask (you can use "Get Info" in Finder
     /// to copy the icon from the .icns file).
     #[clap(verbatim_doc_comment)]
-    target: Option<PathBuf>,
+    targets: Vec<PathBuf>,
 
     /// Write the `.icns` file to the given path.
     /// (Will be written even if a target is also specified.)
@@ -142,7 +142,7 @@ pub struct Options {
     pub mask_path: PathBuf,
     pub color_scheme: ColorScheme,
     pub no_trim: bool,
-    pub target: Option<PathBuf>,
+    pub targets: Vec<PathBuf>,
     pub folder_style: FolderStyle,
     pub empty_folder: bool,
     pub output_icns: Option<PathBuf>,
@@ -263,7 +263,7 @@ pub fn get_options() -> Options {
         mask_path: mask,
         color_scheme: map_color_scheme_auto(args.color_scheme, folder_style),
         no_trim: args.no_trim,
-        target: args.target,
+        targets: args.targets,
         folder_style,
         empty_folder: args.empty_folder,
         output_icns: args.output_icns,

--- a/src/icon_conversion.rs
+++ b/src/icon_conversion.rs
@@ -23,11 +23,11 @@ impl ProgressBarType {
             ProgressBarType::Input => 1,
             ProgressBarType::Conversion => 13 + if options.badge.is_some() { 1 } else { 0 },
             ProgressBarType::OutputWithAssignment => {
-                2 + if matches!(options.set_icon_using, SetIconUsing::Rez) {
-                    7
-                } else {
-                    0
-                }
+                let assignment_steps = match options.set_icon_using {
+                    SetIconUsing::Rez => 7,
+                    _ => 1,
+                };
+                1 + assignment_steps * options.targets.len() as u64
             }
             ProgressBarType::OutputIcns => 1,
         }
@@ -643,20 +643,21 @@ impl IconConversion {
         let args = CommandArgs::new();
         run_command(OSASCRIPT_COMMAND, &args, Some(stdin.as_bytes()))?;
 
-        if target_metadata.is_dir() {
-            // TODO: check for network volume first, only then the appropriate path.
-            if metadata(target_path.join("Icon\r")).is_err()
-                && metadata(target_path.join(".VolumeIcon.icns")).is_err()
-            {
-                eprintln!("Icon was not successfully assigned to the target folder.");
-                exit(1);
-            }
-        } else if options.target.is_some() {
+        if !target_metadata.is_dir() {
             // TODO: this is usually overwritten by the progress bars.
             eprintln!(
                 "Target is not a folder. Please check manually if the icon was assigned correctly."
             );
-        };
+            return Ok(());
+        }
+
+        // TODO: check for network volume first, only then the appropriate path.
+        if metadata(target_path.join("Icon\r")).is_err()
+            && metadata(target_path.join(".VolumeIcon.icns")).is_err()
+        {
+            eprintln!("Icon was not successfully assigned to the target folder.");
+            exit(1);
+        }
 
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,14 +92,10 @@ fn main() {
         handles.push(handle);
     }
 
-    let output_iconset_only = match (
-        &options.target,
-        &options.output_icns,
-        &options.output_iconset,
-    ) {
-        (None, None, Some(output_iconset)) => Some(output_iconset),
-        _ => None,
-    };
+    let mut output_iconset_only = None;
+    if options.targets.is_empty() && options.output_icns.is_none() {
+        output_iconset_only = options.output_iconset.as_ref();
+    }
 
     // Deduplicate this `match` with the one that happens after handle joining.
     let output_progress_bar_type = match output_iconset_only {
@@ -133,20 +129,16 @@ fn main() {
                 )
                 .unwrap();
 
-            let icns_assignment_path = options
-                .target
-                .as_ref()
-                .unwrap_or(&final_output_paths.icns_path);
+            for target in &options.targets {
+                output_icon_conversion
+                    .assign_icns(&options, &final_output_paths.icns_path, target)
+                    .unwrap();
+            }
 
-            output_icon_conversion
-                .assign_icns(
-                    &options,
-                    &final_output_paths.icns_path,
-                    icns_assignment_path,
-                )
-                .unwrap();
-
-            icns_assignment_path
+            options
+                .targets
+                .first()
+                .unwrap_or(&final_output_paths.icns_path)
         }
     };
 

--- a/src/output_paths.rs
+++ b/src/output_paths.rs
@@ -20,39 +20,47 @@ impl PotentialOutputPaths {
             iconset_dir: None,
             icns_path: None,
         };
-        match (
-            &options.target,
-            &options.output_iconset,
-            &options.output_icns,
-        ) {
-            (Some(target), output_iconset, output_icns) => {
+        if !options.targets.is_empty() {
+            for target in &options.targets {
                 println!(
                     "[{}] => assign to [{}]",
                     options.mask_path.display(),
                     target.display()
                 );
-                Self::alt_outputs(options, &mut output_paths, output_iconset, output_icns);
             }
-            (None, None, None) => {
-                let iconset_dir_value = options.mask_path.with_extension("iconset");
-                let icns_path_value = options.mask_path.with_extension("icns");
-                println!(
-                    "[{}] => [{}]",
-                    options.mask_path.display(),
-                    iconset_dir_value.display()
-                );
-                println!(
-                    "[{}] => [{}]",
-                    options.mask_path.display(),
-                    icns_path_value.display()
-                );
-                output_paths.iconset_dir = Some(iconset_dir_value);
-                output_paths.icns_path = Some(icns_path_value);
-            }
-            (None, output_iconset, output_icns) => {
-                Self::alt_outputs(options, &mut output_paths, output_iconset, output_icns);
-            }
+            Self::alt_outputs(
+                options,
+                &mut output_paths,
+                &options.output_iconset,
+                &options.output_icns,
+            );
+            return output_paths;
         }
+
+        if options.output_iconset.is_none() && options.output_icns.is_none() {
+            let iconset_dir_value = options.mask_path.with_extension("iconset");
+            let icns_path_value = options.mask_path.with_extension("icns");
+            println!(
+                "[{}] => [{}]",
+                options.mask_path.display(),
+                iconset_dir_value.display()
+            );
+            println!(
+                "[{}] => [{}]",
+                options.mask_path.display(),
+                icns_path_value.display()
+            );
+            output_paths.iconset_dir = Some(iconset_dir_value);
+            output_paths.icns_path = Some(icns_path_value);
+            return output_paths;
+        }
+
+        Self::alt_outputs(
+            options,
+            &mut output_paths,
+            &options.output_iconset,
+            &options.output_icns,
+        );
         output_paths
     }
 

--- a/test/test-behaviour.test.ts
+++ b/test/test-behaviour.test.ts
@@ -59,6 +59,14 @@ test("Assign folder icon", async () => {
   expect(await tempDir.join("Icon\r").exists()).toBe(true);
 });
 
+test("Assign the same folder icon to multiple targets", async () => {
+  const tempDir1 = await Path.makeTempDir();
+  const tempDir2 = await Path.makeTempDir();
+  await shellOut([EXAMPLES.join("src/apple.png"), tempDir1, tempDir2]);
+  expect(await tempDir1.join("Icon\r").exists()).toBe(true);
+  expect(await tempDir2.join("Icon\r").exists()).toBe(true);
+});
+
 test("Assign folder icon using Rez", async () => {
   const tempDir = await Path.makeTempDir();
   await shellOut([


### PR DESCRIPTION
Reuses a single render when applying the same mask to multiple folders.
This allows us repeated runs to remove repeated work.

Before:
```sh
folderify mask.svg <folder-1>
folderify mask.svg <folder-2>
folderify mask.svg <folder-3>
```

After:
```
folderify mask.svg <folder-1> <folder-2> <folder-3>
```

Thanks for taking a look! 🤍